### PR TITLE
Error handling

### DIFF
--- a/lib/haiku/collection.js
+++ b/lib/haiku/collection.js
@@ -70,13 +70,12 @@ _.extend(Collection.prototype, {
   read: function(){
     var collection = this
       , log = collection.logger
+      , site = this.site
       , isReady
     ;
 
     // Start reading the contents of the directory
     fs.readdir(collection.path, function(err, list){
-      // TODO: emit the error if there are listeners, if there are no
-      // listeners throw the error instead
       if (err) throw err;
 
       log.debug('reading directory: ' + collection.path);
@@ -103,8 +102,6 @@ _.extend(Collection.prototype, {
         ;
 
         fs.stat(itemPath, function(err, stats){
-          // TODO: emit the error if there are listeners, if there are no
-          // listeners throw the error instead
           if (err) throw err;
 
           // if it's a directory, create a collection object

--- a/lib/haiku/page.js
+++ b/lib/haiku/page.js
@@ -115,15 +115,14 @@ _.extend(Page.prototype, {
   read: function() {
     var page = this
       , log = this.logger
+      , site = this.site
     ;
 
     log.debug('reading file: ' + page.path);
 
     // we start by just reading the raw data asynchronously
     fs.readFile(page.path, 'utf8', function(err, data) {
-      // TODO: emit the error if there are listeners, if there are no
-      // listeners throw the error instead
-      if (err) throw err;
+      if (err) return site.handleError(err);
 
       // wonderful! we have the content! let's turn it into a resource
       // (extract the front-matter, split into attributes and data)

--- a/lib/haiku/site.js
+++ b/lib/haiku/site.js
@@ -260,6 +260,10 @@ _.extend(Site.prototype, {
         });
       });
     });
+  },
+  handleError: function(err){
+    if (! err) return;
+
   }
 });
 

--- a/lib/haiku/site.js
+++ b/lib/haiku/site.js
@@ -143,14 +143,11 @@ _.extend(Site.prototype, {
       // Make sure this is a valid directory before making it into a
       // `Collection` object
       fs.stat(_path, function(err, stats){
-        // TODO: emit the error if there are listeners, if there are no
-        // listeners throw the error instead
-        if (err) throw err;
+        if (err) return site.handleError(err);
 
         if (! stats.isDirectory) {
-          // TODO: the same as the TODO above, also this should have a more
-          // meaningful error message
-          throw new Error(_path + "must be a directory.");
+          err = new Error(_path + ' must be a directory.');
+          return site.handleError(err);
         }
 
         // Create a new `Collection` object for this directory

--- a/lib/haiku/site.js
+++ b/lib/haiku/site.js
@@ -261,9 +261,23 @@ _.extend(Site.prototype, {
       });
     });
   },
-  handleError: function(err){
+  handleError: function(err, message){
     if (! err) return;
 
+    var site = this
+      , events = _(this.listeners('error'))
+      , log = this.logger
+    ;
+
+    if (events.size()){
+      log.debug('handling error through event listeners');
+
+      if (message) err.message = [message, err.message].join('\n');
+
+      return site.emit('error', err);
+    } else {
+      throw err;
+    }
   }
 });
 

--- a/lib/haiku/site.js
+++ b/lib/haiku/site.js
@@ -261,6 +261,15 @@ _.extend(Site.prototype, {
       });
     });
   },
+
+  // # site.handleError(err, message)
+  //
+  // Takes the err and either emits an error event or throws it depending
+  // wether or not any error events have been added to the site instance`.
+  //
+  // An optional `message` string can be passed in, this will be prepended to
+  // the Error's original message. This is helpful for adding extra info about
+  // why the error occurred
   handleError: function(err, message){
     if (! err) return;
 

--- a/lib/haiku/site.js
+++ b/lib/haiku/site.js
@@ -143,11 +143,11 @@ _.extend(Site.prototype, {
       // Make sure this is a valid directory before making it into a
       // `Collection` object
       fs.stat(_path, function(err, stats){
-        if (err) return site.handleError(err);
+        if (err) throw err;
 
         if (! stats.isDirectory) {
           err = new Error(_path + ' must be a directory.');
-          return site.handleError(err);
+          throw err;
         }
 
         // Create a new `Collection` object for this directory
@@ -257,33 +257,6 @@ _.extend(Site.prototype, {
         });
       });
     });
-  },
-
-  // # site.handleError(err, message)
-  //
-  // Takes the err and either emits an error event or throws it depending
-  // wether or not any error events have been added to the site instance`.
-  //
-  // An optional `message` string can be passed in, this will be prepended to
-  // the Error's original message. This is helpful for adding extra info about
-  // why the error occurred
-  handleError: function(err, message){
-    if (! err) return;
-
-    var site = this
-      , events = _(this.listeners('error'))
-      , log = this.logger
-    ;
-
-    if (events.size()){
-      log.debug('handling error through event listeners');
-
-      if (message) err.message = [message, err.message].join('\n');
-
-      return site.emit('error', err);
-    } else {
-      throw err;
-    }
   }
 });
 

--- a/test/haiku/collection_test.js
+++ b/test/haiku/collection_test.js
@@ -7,6 +7,8 @@ var helper = require('../test_helper')
   , events = require('events')
   , _ = require('underscore')
   , Page = require('haiku/page')
+  , sinon = require('sinon')
+  , fs = require('fs')
 ;
 
 vows.describe('Collection').addBatch({
@@ -79,9 +81,52 @@ vows.describe('Collection').addBatch({
         assert.isObject(collection.folder['posts']);
         assert.instanceOf(collection.folder['posts'], Collection);
       },
-      'when `fs.stat` errs': 'pending'
     },
-    'when `fs.readdir` errs': 'pending'
+    'errors': {
+      'on `fs.readdir`': {
+        'with NO error listeners':{
+          'should throw': sinon.test(function(){
+            var site = new(Site)
+              , collection = new Collection({
+                  site: site
+                })
+              , err = new Error('Fake fs.readdir error')
+              , sinon = this
+            ;
+
+            sinon.stub(fs, 'readdir', function(_path, callback){
+              return callback(err, []);
+            });
+
+            assert.throws(function(){
+              collection.read();
+            });
+
+          })
+        }
+      },
+      'on `fs.stat`': {
+        'with NO error listeners':{
+          'should throw': sinon.test(function(){
+            var site = new(Site)
+              , collection = new Collection({
+                  site: site
+                })
+              , err = new Error('Fake fs.stat error')
+              , sinon = this
+            ;
+
+            sinon.stub(fs, 'stat', function(_path, callback){
+              return callback(err, {});
+            });
+
+            assert.throws(function(){
+              collection.read();
+            });
+          })
+        },
+      }
+    }
   },
   '#find()': {
     topic: function(){

--- a/test/haiku/page_test.js
+++ b/test/haiku/page_test.js
@@ -198,8 +198,8 @@ vows.describe('Page').addBatch({
       }
     },
     'errors': {
-      'when `fs.readFile` has an err': {
-        'should call `site.handleError`': sinon.test(function(){
+      'on `fs.readFile`': {
+        'should throw': sinon.test(function(){
           var site = new(Site)
             , page = new Page({ site: site })
             , err = new Error('Fake fs.readfile error')
@@ -210,12 +210,10 @@ vows.describe('Page').addBatch({
             return callback(err, '');
           });
 
-          sinon.stub(page.site, 'handleError');
 
-          page.read();
-
-          assert.ok(fs.readFile.called);
-          assert.ok(page.site.handleError.called);
+          assert.throws(function(){
+            page.read();
+          });
         })
       }
     }

--- a/test/haiku/page_test.js
+++ b/test/haiku/page_test.js
@@ -6,6 +6,8 @@ var helper = require('../test_helper')
   , Page = require('haiku/page')
   , _ = require('underscore')
   , events = require('events')
+  , sinon = require('sinon')
+  , fs = require('fs')
 ;
 
 vows.describe('Page').addBatch({
@@ -195,7 +197,28 @@ vows.describe('Page').addBatch({
         assert.equal(page.attributes.title, 'This is the homepage');
       }
     },
-    'on `fs.readFile` error': 'pending'
+    'errors': {
+      'when `fs.readFile` has an err': {
+        'should call `site.handleError`': sinon.test(function(){
+          var site = new(Site)
+            , page = new Page({ site: site })
+            , err = new Error('Fake fs.readfile error')
+            , sinon = this
+          ;
+
+          sinon.stub(fs, 'readFile', function(_path, encoding, callback){
+            return callback(err, '');
+          });
+
+          sinon.stub(page.site, 'handleError');
+
+          page.read();
+
+          assert.ok(fs.readFile.called);
+          assert.ok(page.site.handleError.called);
+        })
+      }
+    }
   },
   '#parser()': {
     topic: function(){

--- a/test/haiku/site_test.js
+++ b/test/haiku/site_test.js
@@ -262,5 +262,38 @@ vows.describe('haiku.Site').addBatch({
     //     }
     //   }
     // }
+  },
+  '#handleError(err)': {
+    topic: function(){
+      return new(Site);
+    },
+    'should exist': function(site){
+      assert.isFunction(site.handleError);
+    },
+    'when `err` is falsely': {
+      'should not raise an error': function(site){
+        assert.doesNotThrow(function(){ site.handleError(); });
+        assert.doesNotThrow(function(){ site.handleError(null); });
+        assert.doesNotThrow(function(){ site.handleError(undefined); });
+        assert.doesNotThrow(function(){ site.handleError(false); });
+      },
+      'should return undefined': function(site){
+        assert.isUndefined(site.handleError());
+        assert.isUndefined(site.handleError(null));
+        assert.isUndefined(site.handleError(undefined));
+        assert.isUndefined(site.handleError(false));
+      }
+    },
+    'when there is an "error" event listener': {
+      'when `err` is an error object': 'pending',
+      'when `err` is a string': 'pending'
+    },
+    'when there is *NOT* an "error" event listener': {
+      'when `err` is an error object': 'pending',
+      'when `err` is a string': 'pending'
+    }
+    // if there are no error events throw
+    // error message
+    // error stack
   }
 }).export(module);

--- a/test/haiku/site_test.js
+++ b/test/haiku/site_test.js
@@ -155,8 +155,8 @@ vows.describe('haiku.Site').addBatch({
       }
     },
     'errors': {
-      'when `fs.stat` has an error': {
-        'should call `site.handleError`': sinon.test(function(){
+      'on `fs.stat`': {
+        'should throw': sinon.test(function(){
           var site = new(Site)
             , err = new Error('Fake fs.stats error')
             , sinon = this
@@ -166,16 +166,13 @@ vows.describe('haiku.Site').addBatch({
             return callback(err, {});
           });
 
-          sinon.stub(site, 'handleError');
-
-          site.read();
-
-          assert.ok(fs.stat.called);
-          assert.ok(site.handleError.called);
+          assert.throws(function(){
+            site.read();
+          });
         })
       },
-      'when trying to read a non-directory': {
-        'should call `site.handleError`': sinon.test(function(){
+      'on `fs.stat` when `! stats.isDirectory`': {
+        'should throw': sinon.test(function(){
           var site = new(Site)
             , sinon = this
             , message
@@ -185,16 +182,10 @@ vows.describe('haiku.Site').addBatch({
             return callback(null, { isDirectory: false });
           });
 
-          sinon.stub(site, 'handleError');
 
-          site.read();
-
-          assert.ok(fs.stat.called);
-          assert.ok(site.handleError.called);
-
-          message = site.handleError.args[0][0].message;
-
-          assert.match(message, /must be a directory/);
+          assert.throws(function(){
+            site.read();
+          });
         })
       }
     }
@@ -306,70 +297,5 @@ vows.describe('haiku.Site').addBatch({
     //     }
     //   }
     // }
-  },
-  '#handleError(err)': {
-    topic: function(){
-      return new (Site);
-    },
-    'should exist': function(site){
-      assert.isFunction(site.handleError);
-    },
-    'when `err` is falsely': {
-      'should not throw an error': function(site){
-        assert.doesNotThrow(function(){ site.handleError(); });
-        assert.doesNotThrow(function(){ site.handleError(null); });
-        assert.doesNotThrow(function(){ site.handleError(undefined); });
-        assert.doesNotThrow(function(){ site.handleError(false); });
-      },
-      'should return undefined': function(site){
-        assert.isUndefined(site.handleError());
-        assert.isUndefined(site.handleError(null));
-        assert.isUndefined(site.handleError(undefined));
-        assert.isUndefined(site.handleError(false));
-      }
-    },
-    'when there is an "error" event listener': {
-      topic: function(site){
-        site.on('error', function(e){});
-
-        return site;
-      },
-      'when `err` is an error object': {
-        'should not throw': function(site){
-          assert.doesNotThrow(function(){
-            site.handleError(new Error);
-          });
-        },
-        'event listener should get Error': sinon.test(function(site){
-          var spy = sinon.spy()
-            , err = new Error('Secret plans.')
-          ;
-
-          site.on('error', spy);
-          site.handleError(err);
-
-          assert.ok(spy.called);
-          assert.equal(spy.args[0][0], err);
-        })
-      }
-    },
-    'when there is *NOT* an "error" event listener': {
-      topic: function(){
-        var site = new(Site);
-
-        site.removeAllListeners('error');
-
-        return site;
-      },
-      'when `err` is an error object': {
-        'should throw': function(site){
-          var err = new Error('Gah.');
-
-          assert.throws(function(){
-            site.handleError(err);
-          });
-        }
-      }
-    }
   }
 }).export(module);

--- a/test/haiku/site_test.js
+++ b/test/haiku/site_test.js
@@ -153,6 +153,50 @@ vows.describe('haiku.Site').addBatch({
         assert.isObject(site.content.folder.posts);
         assert.instanceOf(site.content.folder.posts, Collection);
       }
+    },
+    'errors': {
+      'when `fs.stat` has an error': {
+        'should call `site.handleError`': sinon.test(function(){
+          var site = new(Site)
+            , err = new Error('Fake fs.stats error')
+            , sinon = this
+          ;
+
+          sinon.stub(fs, 'stat', function(_path, callback){
+            return callback(err, {});
+          });
+
+          sinon.stub(site, 'handleError');
+
+          site.read();
+
+          assert.ok(fs.stat.called);
+          assert.ok(site.handleError.called);
+        })
+      },
+      'when trying to read a non-directory': {
+        'should call `site.handleError`': sinon.test(function(){
+          var site = new(Site)
+            , sinon = this
+            , message
+          ;
+
+          sinon.stub(fs, 'stat', function(_path, callback){
+            return callback(null, { isDirectory: false });
+          });
+
+          sinon.stub(site, 'handleError');
+
+          site.read();
+
+          assert.ok(fs.stat.called);
+          assert.ok(site.handleError.called);
+
+          message = site.handleError.args[0][0].message;
+
+          assert.match(message, /must be a directory/);
+        })
+      }
     }
   },
   '#find(route)': {

--- a/test/haiku/site_test.js
+++ b/test/haiku/site_test.js
@@ -265,13 +265,13 @@ vows.describe('haiku.Site').addBatch({
   },
   '#handleError(err)': {
     topic: function(){
-      return new(Site);
+      return new (Site);
     },
     'should exist': function(site){
       assert.isFunction(site.handleError);
     },
     'when `err` is falsely': {
-      'should not raise an error': function(site){
+      'should not throw an error': function(site){
         assert.doesNotThrow(function(){ site.handleError(); });
         assert.doesNotThrow(function(){ site.handleError(null); });
         assert.doesNotThrow(function(){ site.handleError(undefined); });
@@ -285,15 +285,47 @@ vows.describe('haiku.Site').addBatch({
       }
     },
     'when there is an "error" event listener': {
-      'when `err` is an error object': 'pending',
-      'when `err` is a string': 'pending'
+      topic: function(site){
+        site.on('error', function(e){});
+
+        return site;
+      },
+      'when `err` is an error object': {
+        'should not throw': function(site){
+          assert.doesNotThrow(function(){
+            site.handleError(new Error);
+          });
+        },
+        'event listener should get Error': sinon.test(function(site){
+          var spy = sinon.spy()
+            , err = new Error('Secret plans.')
+          ;
+
+          site.on('error', spy);
+          site.handleError(err);
+
+          assert.ok(spy.called);
+          assert.equal(spy.args[0][0], err);
+        })
+      }
     },
     'when there is *NOT* an "error" event listener': {
-      'when `err` is an error object': 'pending',
-      'when `err` is a string': 'pending'
+      topic: function(){
+        var site = new(Site);
+
+        site.removeAllListeners('error');
+
+        return site;
+      },
+      'when `err` is an error object': {
+        'should throw': function(site){
+          var err = new Error('Gah.');
+
+          assert.throws(function(){
+            site.handleError(err);
+          });
+        }
+      }
     }
-    // if there are no error events throw
-    // error message
-    // error stack
   }
 }).export(module);


### PR DESCRIPTION
After messing around with adding error handlers/ wrapper it turned out to be a pretty bad idea, primarily because it becomes very dificult to to pinpoint errors produced by node-core functions using this methodology.

It also messes with the `err.stack`.

I moved back to using the standard way of doing:

```
if (err) throw err;
```

This gives us a more concise stack.

I would like to hook up the error events but I am thinking we should wait until this actually becomes a feature request before proceeding and work on throwing concise errors for things like the ubiquitous Mustache errors we were getting in the meantime.

This pull request also includes tests for throwing errors where we expect them.
